### PR TITLE
fix: moves flash msg to the bottom

### DIFF
--- a/src/components/FlashMsg.jsx
+++ b/src/components/FlashMsg.jsx
@@ -6,7 +6,7 @@ export default function FlashMsg({ flash, setFlash }) {
 
 	return (
 		<div
-			className={`max-w-fit flex items-center gap-10 justify-between text-primary  sticky py-3 px-5 rounded-lg shadow-lg top-5 mx-auto ${bgColor}`}
+			className={`min-w-max flex items-center gap-10 justify-between text-primary fixed py-3 px-5 rounded-lg shadow-lg left-1/2 -translate-x-1/2 bottom-12 ${bgColor}`}
 		>
 			{flash.msg}
 			<FontAwesomeIcon


### PR DESCRIPTION
### 🛠️ Fixes #Issue_Number

Closes #20 

### 👨‍💻 What's being changed:

Moves the flash messages to the bottom instead of the top. So the posts don't pop down when a flash message shows up.

### Type of change

<!-- Please delete options that are not relevant. -->

<!-- Follow the below conventions to check the box -->
<!--
To mark a box just add 'x' between the [] with any spaces.

[x] This is a marked box. ✅
[ x ] This is NOT marked box. ❌
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### ✔️ Check List (Check all the applicable boxes) 

<!-- Mark all the applicable boxes -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

### 📄 Note to reviewers
<!-- Fill in anything that you want to let the reviewers know about -->
<!-- If you don't have anything for the reviewers, please remove this section -->

### 📷 Screenshots

Original | Updated
:----------------------:|:-----------:
![image](https://user-images.githubusercontent.com/64529217/183097425-5d94aa3a-e46b-4b6d-96b2-7e2bd898f9b2.png)  |  ![image](https://user-images.githubusercontent.com/64529217/183097182-c7fe8c7b-37bb-4537-ae73-61b9d1abc666.png) 
