### PR TITLE
Store dark/light theme preference in local storage

### DIFF
--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const useDarkMode = () => {
-	const [theme, setTheme] = useState('light');
+	const [theme, setTheme] = useState(localStorage.getItem('theme') || 'light');
 
 	const colorTheme = theme === 'light' ? 'dark' : 'light';
 	useEffect(() => {
@@ -9,6 +9,9 @@ const useDarkMode = () => {
 		root.classList.add(theme);
 		root.classList.remove(colorTheme);
 	}, [setTheme, colorTheme]);
+
+	localStorage.setItem('theme', theme);
+	
 	return [setTheme, colorTheme];
 };
 


### PR DESCRIPTION
Currently, the user can switch between dark and light mode but it's not persistent. 

So i use  [LocalStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to store  current theme and retrieved on page load to set the default mode.