### PR TITLE
Redirect to home after deleting post

### DIFF
--- a/src/components/posts/Post.jsx
+++ b/src/components/posts/Post.jsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import UserContext from "../../contexts/UserContext.jsx";
 import FlashContext from "../../contexts/FlashContext.jsx";
 // FIREBASE
@@ -29,6 +29,7 @@ export default function Post({ data }) {
   const [postOwner, setPostOwner] = useState({});
   const { flash } = useContext(FlashContext);
   const { user } = useContext(UserContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     setIsLiked(data.likedBy.includes(user?.uid));
@@ -56,11 +57,11 @@ export default function Post({ data }) {
   }
 
   function deletePost() {
+    navigate("/");
     const imgId = data.img.split("%2F")[1].split("?")[0];
     deleteDoc(docRef)
       .then(() => deleteObject(ref(storage, `images/${imgId}`)))
       .then(() => {
-        Redirect;
         flash((prevFlash) => ({
           ...prevFlash,
           show: true,

--- a/src/components/posts/Post.jsx
+++ b/src/components/posts/Post.jsx
@@ -55,7 +55,6 @@ export default function Post({ data }) {
     });
   }
 
-  // TODO: delete the image from firebase storage as well
   function deletePost() {
     const imgId = data.img.split("%2F")[1].split("?")[0];
     deleteDoc(docRef)


### PR DESCRIPTION
### Related Issue/Addition to code
- After deleting a post from the details page, it throws an error as after deleting there is no data to render the details.

### 👨‍💻 What's being changed:

<!-- List all the proposed changes in your PR. -->
Simply redirects the user to the home page after deleting a post so React doesn't try to render the deleted post.

### Type of change

<!-- Please delete options that are not relevant. -->

<!-- Follow the below conventions to check the box -->
<!--
To mark a box just add 'x' between the [] with any spaces.

[x] This is a marked box. ✅
[ x ] This is NOT marked box. ❌
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### ✔️ Check List (Check all the applicable boxes) 

<!-- Mark all the applicable boxes -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.